### PR TITLE
Fix requirement to python-wget

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ descartes
 geopandas
 beautifulsoup4
 basemap
-wget
+python-wget


### PR DESCRIPTION
## Overview

`wget` is the actual wget, this actually installs `python-wget` instead.