### PR TITLE
Updating ogh.py to relative reference ogh_meta

### DIFF
--- a/ogh/ogh.py
+++ b/ogh/ogh.py
@@ -28,7 +28,6 @@ import geopandas as gpd
 import ftplib, urllib, wget, bz2
 from bs4 import BeautifulSoup as bs
 
-# ogh supplemental info
 from ogh_meta import meta_file
 
 
@@ -51,7 +50,6 @@ class ogh_meta:
     def values(self):
         return(self.__meta_data.values())
                
-        
 def saveDictOfDf(outfilepath, dictionaryObject):
     """
     Save a json file from a pickle'd python dictionary-of-dataframes object
@@ -65,7 +63,6 @@ def saveDictOfDf(outfilepath, dictionaryObject):
         pickle.dump(dictionaryObject, f)
         f.close()
 
-        
 def readDictOfDf(infilepath):
     """
     Read in a json file that contains pickle'd python objects
@@ -77,7 +74,6 @@ def readDictOfDf(infilepath):
         dictionaryObject = pickle.load(f)
         f.close()
     return(dictionaryObject)
-
 
 def reprojShapefile(sourcepath, outpath=None, newprojdictionary={'proj':'longlat', 'ellps':'WGS84', 'datum':'WGS84'}):
     """
@@ -96,7 +92,6 @@ def reprojShapefile(sourcepath, outpath=None, newprojdictionary={'proj':'longlat
     shpfile = shpfile.to_crs(newprojdictionary)
     shpfile.to_file(outpath)
 
-    
 def getFullShape(shapefile):
     """
     Generate a MultiPolygon to represent each shape/polygon within the shapefile
@@ -1334,7 +1329,7 @@ def aggregate_space_time_sum(df_dict, suffix, start_date, end_date):
 
 def gridclim_dict(mappingfile,dataset,gridclimname=None,metadata=None,min_elev=None,max_elev=None,
                   file_start_date=None,file_end_date=None,file_time_step=None,file_colnames=None,file_delimiter=None,
-                  subset_start_date=None,subset_end_date=None,df_dict=None,colvar=None):
+                  subset_start_date=None,subset_end_date=None,df_dict=None,colvar=None, gridcell_limit=True):
     """
     # pipelined operation for assimilating data, processing it, and standardizing the plotting
     
@@ -1352,6 +1347,7 @@ def gridclim_dict(mappingfile,dataset,gridclimname=None,metadata=None,min_elev=N
     subset_start_date: (date) the start date of a date range of interest
     subset_end_date: (date) the end date of a date range of interest
     df_dict: (dict) an existing dictionary where new computations will be stored
+    gridcell_limit: (true/false) if true, the daily dataframes for each variable will be removed if it exceeds 300 gridded cells
     """
     
     # generate the climate locations and n_stations
@@ -1428,9 +1424,9 @@ def gridclim_dict(mappingfile,dataset,gridclimname=None,metadata=None,min_elev=N
                                                     start_date=subset_start_date,end_date=subset_end_date))
 
         # if the number of stations exceeds 500, remove daily time-series dataframe
-        if len(locations_df)>300:
-           del df_dict[eachvardf]
-                
+        if gridcell_limit is True & len(locations_df)>300:
+            del df_dict[eachvardf]
+            
     return(df_dict)
 
 
@@ -2571,7 +2567,7 @@ def monthlyExceedence_cfs (df_dict,daily_streamflow_dfname,gridcell_area,exceeda
         Exceed = pd.concat([Exceed, pd.DataFrame(month_res).T], axis=0)
     
     Exceed.index=months
-    df_dict['EXCEED{0}_{1}'.format(exceedance,dataset)] = Exceed
+    df_dict['EXCEED{0}_cfs_{1}'.format(exceedance,dataset)] = Exceed
     return(df_dict)
 
 

--- a/ogh/ogh.py
+++ b/ogh/ogh.py
@@ -28,7 +28,7 @@ import geopandas as gpd
 import ftplib, urllib, wget, bz2
 from bs4 import BeautifulSoup as bs
 
-from ogh_meta import meta_file
+from .ogh_meta import meta_file
 
 
 class ogh_meta:

--- a/tutorials/ogh.py
+++ b/tutorials/ogh.py
@@ -1347,6 +1347,7 @@ def gridclim_dict(mappingfile,dataset,gridclimname=None,metadata=None,min_elev=N
     subset_start_date: (date) the start date of a date range of interest
     subset_end_date: (date) the end date of a date range of interest
     df_dict: (dict) an existing dictionary where new computations will be stored
+    gridcell_limit: (true/false) if true, the daily dataframes for each variable will be removed if it exceeds 300 gridded cells
     """
     
     # generate the climate locations and n_stations

--- a/tutorials/ogh.py
+++ b/tutorials/ogh.py
@@ -28,7 +28,7 @@ import geopandas as gpd
 import ftplib, urllib, wget, bz2
 from bs4 import BeautifulSoup as bs
 
-from ogh_meta import meta_file
+from .ogh_meta import meta_file
 
 
 class ogh_meta:


### PR DESCRIPTION
Somehow the relative reference got overwritten. This should ensure that the functionalities are intact for the pypi and conda updates.

A number of tutorial notebooks have been updated in a previous pull. The parameter addition in gridclim_dict would not affect the notebook performance, but it gives the user more flexibility to turn off the 300 gridded cell limit.